### PR TITLE
Fix incorrect usage example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Default configuration is:
 ```js
 {
     "pluginsConfig": {
-        "fontSettings": {
+        "fontsettings": {
             "theme": null, // 'sepia', 'night' or 'white',
             "family": 'sans',// 'serif' or 'sans',
             "size": 2 // 1 - 4

--- a/assets/buttons.js
+++ b/assets/buttons.js
@@ -87,7 +87,7 @@ require(["gitbook", "lodash", "jQuery"], function(gitbook, _, $) {
         fontState = gitbook.storage.get("fontState", {
             size: config.size || 2,
             family: FAMILY[config.family || "sans"],
-            theme: THEMES[config.theme || "white"]
+            theme: THEMES[config.theme || "night"]
         });
 
         update();


### PR DESCRIPTION
In README.md, `fontSettings` should be `fontsettings`.
